### PR TITLE
Change rehid link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rehid-configs-files-3DS
 Collection of .json files for remap controls on 3DS using **Rehid**.
 
-Download **RehidHelper** homebrew app (and **Rehid**) from here: https://github.com/hax0kartik/rehid/releases/tag/v2.0                                                           
+Download **RehidHelper** homebrew app (and **Rehid**) from here: https://github.com/hax0kartik/rehid/releases/latest                                                        
 Install **RehidHelper** on your 3DS , open it, scan the QR code of your desired game, and that's it, you already installed the remap!
 
 List of remaped games:


### PR DESCRIPTION
This changes the rehid link to always point to the latest release, which should prevent having to manually update the link with each new release.